### PR TITLE
css updates for new layout

### DIFF
--- a/src/components/RestaurantList/RestaurantList.scss
+++ b/src/components/RestaurantList/RestaurantList.scss
@@ -13,6 +13,7 @@
   border: $default-border;
   padding-bottom: 20px;
   padding-top: 20px;
+  width: auto;
 
   h2 {
     font-weight: bold;

--- a/src/routes/team/home/Home.scss
+++ b/src/routes/team/home/Home.scss
@@ -24,7 +24,7 @@
 
 .restaurantList {
   flex-grow: 1;
-  margin-top: 1em;
+  padding-top: 1em;
 }
 
 @media (min-width: 1000px) {


### PR DESCRIPTION
* Override container class width defaults on large screens (fixes #119)

* Change restaurant list wrapper to use padding-top instead of margin-top to preserve background appearance (fixes #117)