### PR TITLE
Remove unnecessary env variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,10 +8,6 @@ SUPERUSER_NAME=
 SUPERUSER_PASSWORD= 
 SUPERUSER_EMAIL=
 
-# Tell server that BrowserSync is running to pass original port through
-# to be used with WebSockets. (optional)
-BS_RUNNING=true
-
 # Credentials for your Google Developer app (APIKEY optional)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/src/initialState.js
+++ b/src/initialState.js
@@ -45,7 +45,7 @@ const getInitialState = () => ({
     didInvalidate: true,
     items: []
   },
-  wsPort: process.env.BS_RUNNING ? wsPort : 0
+  wsPort: module.hot ? wsPort : 0
 });
 
 export default (stateData) => {


### PR DESCRIPTION
`BS_RUNNING` is unnecessary as we can simply use `module.hot` to see if we’re within RSK’s dev server clutches.