### PR TITLE
Reject instead of throw when handling error response

### DIFF
--- a/src/core/ApiClient.js
+++ b/src/core/ApiClient.js
@@ -13,10 +13,13 @@ export function processResponse(response, dispatch) {
       if (response.status === 401) {
         history.replace(`/login?next=${history.location.pathname}`);
       } else {
-        dispatch(flashError(err.message))
-        throw err;
+        dispatch(flashError(err.message));
+        // returning a rejection instead of throwing an error prevents
+        // react-error-overlay from triggering.
+        return Promise.reject(err.message);
       }
     }
+    return undefined;
   });
 }
 

--- a/src/core/tests/ApiClient.test.js
+++ b/src/core/tests/ApiClient.test.js
@@ -57,7 +57,7 @@ describe('processResponse', () => {
 
     return processResponse(response, dispatch).catch((err) => {
       expect(dispatch.args[0][0].type).to.eq('FLASH_ERROR');
-      expect(err.message).to.eq('Oh No');
+      expect(err).to.eq('Oh No');
     });
   });
 


### PR DESCRIPTION
Locally prevents react-error-overlay from triggering.