### PR TITLE
Downgrade bcrypt further

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "bcrypt": "^4.0.1",
+    "bcrypt": "^3.0.8",
     "bluebird": "^3.5.1",
     "body-parser": "^1.18.3",
     "classnames": "^2.2.6",


### PR DESCRIPTION
4.x doesn't work with Node 9.x