### PR TITLE
Fix Team map event listener

### DIFF
--- a/src/components/TeamMap/TeamMap.tsx
+++ b/src/components/TeamMap/TeamMap.tsx
@@ -31,13 +31,18 @@ class TeamMap extends Component<TeamMapProps> {
 
   setMap = ({ map }: { map: google.maps.Map }) => {
     this.map = map;
-    this.map.addListener("bounds_changed", () => {
+    this.map.addListener("idle", () => {
       const center = map.getCenter();
+
       if (center) {
-        this.props.setCenter({
-          lat: center.lat(),
-          lng: center.lng(),
-        });
+        const lat = center.lat();
+        const lng = center.lng();
+        if (this.props.center?.lat !== lat || this.props.center?.lng !== lng) {
+          this.props.setCenter({
+            lat,
+            lng,
+          });
+        }
       }
     });
   };


### PR DESCRIPTION
`bounds_changed` was firing while dragging, stopping the drag. Listening for `idle` waits until the dragging (or anything else) is complete.